### PR TITLE
Disable logging input data by default #7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,10 @@ endif(UNIX)
 
 
 set(outname "cyber-notifier")
+set(PROTOBUF_LIB "/opt/nats.c-1.8.0/pbuf/lib/linux/libprotobuf-c.so")
 
 # Build the executable
 add_executable(${outname} ${PROJECT_SOURCE_DIR}/notifier.cpp)
 
 # Link
-target_link_libraries(${outname} nats ${NATS_EXTRA_LIB})
+target_link_libraries(${outname} nats ${NATS_EXTRA_LIB} ${PROTOBUF_LIB})

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update \
 COPY --from=builder /opt/cyberway.notifier/build/cyber-notifier /opt/cyberway/bin/cyber-notifier
 COPY --from=builder /etc/version.json /opt/cyberway/cyber-notifier.version
 COPY --from=builder /usr/local/lib/libnats.so.1.8.0 /usr/local/lib/
-COPY --from=builder /opt/cnats-1.8.0/pbuf/lib/linux/libprotobuf-c.so /usr/local/lib/
+COPY --from=builder /opt/nats.c-1.8.0/pbuf/lib/linux/libprotobuf-c.so /usr/local/lib/
 
 RUN ldconfig
 

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -4,7 +4,7 @@ FROM cyberway/builder:$buildtype as builder
 ARG branch=master
 
 RUN cd /opt && wget https://github.com/nats-io/cnats/archive/v1.8.0.tar.gz && tar -xzf v1.8.0.tar.gz \
-    && cd cnats-1.8.0 && mkdir build && cd ./build && cmake .. && make && make install
+    && cd nats.c-1.8.0 && mkdir build && cd ./build && cmake .. && make && make install
 
 RUN echo "/opt/cnats-1.8.0/pbuf/lib/linux/" > /etc/ld.so.conf.d/protobuf-c.conf && ldconfig
 

--- a/notifier.cpp
+++ b/notifier.cpp
@@ -2,6 +2,7 @@
 #include "options.h"
 #include <string>
 #include <iostream>
+#include <signal.h>
 
 static const char* usage =
     "-txt           text to send (default is 'hello')\n";
@@ -33,9 +34,15 @@ static void _publish_ack_cb(const char* guid, const char* error, void* closure) 
     // done = true;
 }
 
+static void sigusr1_handler(int signum) {
+    print = !print;
+}
+
 int main(int argc, char** argv) {
     opts = parseArgs(argc, argv, usage);
     std::cout << "Sending pipe messages" << std::endl;
+
+    signal(SIGUSR1, sigusr1_handler);
 
     // Now create STAN Connection Options and set the NATS Options.
     stanConnOptions* connOpts;
@@ -61,7 +68,9 @@ int main(int argc, char** argv) {
             nats_Sleep(50);
             continue;
         } else {
-            std::cout << line << std::endl;
+            if (print) {
+                std::cout << line << std::endl;
+            }
         }
         if (!line.size()) {
             subj = "bad.empty";


### PR DESCRIPTION
Resolves #7
EventEngine genesis produce too much data, but we need logging in normal work.
So, cyberway-notifier started with disabled logging input data and after EE genesis send testnet startup script enables logging by signal.